### PR TITLE
Conj only checks two args

### DIFF
--- a/src/dynalint/lint.clj
+++ b/src/dynalint/lint.clj
@@ -1352,23 +1352,22 @@
        ([] (check-nargs #(<= 2 %) this-var []))
        ([a1] (check-nargs #(<= 2 %) this-var [a1]))
        ([t a & args]
-        (cond
-          (not ((some-fn nil? coll?) t))
-            (error "First argument to clojure.core/conj must be a persistent collection or nil: "
-                   (short-ds t))
-          (and (map? t)
-               (some
-                (complement 
-                  (some-fn 
-                    #(instance? java.util.Map$Entry %)
-                    (every-pred vector?
-                                #(#{2} (count %)))
-                    (every-pred seq-succeeds?
-                                (partial every? #(instance? java.util.Map$Entry %)))
-                    nil?))
-                (cons a args)))
-            (error "Can only conj nil, a map entry, a vector pair or a seqable of map entries onto a map: "
-                   (short-ds a)))
+        (error-if-not ((some-fn nil? coll?) t)
+          "First argument to clojure.core/conj must be a persistent collection or nil: "
+          (short-ds t))
+        (when (map? t)
+          (doseq [x (cons a args)]
+            (error-if-not
+             ((some-fn
+               #(instance? java.util.Map$Entry %)
+               (every-pred vector?
+                           #(#{2} (count %)))
+               (every-pred seq-succeeds?
+                           (partial every? #(instance? java.util.Map$Entry %)))
+               nil?)
+              x)
+              "Can only conj nil, a map entry, a vector pair or a seqable of map entries onto a map: "
+              (short-ds x))))
         (apply original t a args))))
    #'clojure.core/next
     (args-1-wrapper clojure.core_SLASH_next

--- a/src/dynalint/lint.clj
+++ b/src/dynalint/lint.clj
@@ -685,7 +685,7 @@
     (args-1-wrapper clojure.core_SLASH_namespace
       [original this-var]
        ([x]
-        (error-if-not ((some-fn #(instance? clojure.lang.Named %)) x)
+        (error-if-not (instance? clojure.lang.Named x)
           "First argument to clojure.core/namespace must be named: "
           (short-ds x))
         (original x)))
@@ -693,7 +693,7 @@
     (args-1-wrapper clojure.core_SLASH_remove-all-methods
       [original this-var]
        ([multifn]
-        (error-if-not ((some-fn #(instance? clojure.lang.MultiFn %)) multifn)
+        (error-if-not (instance? clojure.lang.MultiFn multifn)
           "First argument to clojure.core/remove-all-methods must be a multimethod: "
           (short-ds multifn))
         (original multifn)))
@@ -701,7 +701,7 @@
     (args-2-wrapper clojure.core_SLASH_remove-method
       [original this-var]
        ([multifn dispatch-val]
-        (error-if-not ((some-fn #(instance? clojure.lang.MultiFn %)) multifn)
+        (error-if-not (instance? clojure.lang.MultiFn multifn)
           "First argument to clojure.core/remove-method must be a multimethod: "
           (short-ds multifn))
         (original multifn dispatch-val)))
@@ -709,7 +709,7 @@
     (args-3-wrapper clojure.core_SLASH_prefer-method
       [original this-var]
        ([multifn dispatch-val-x dispatch-val-y]
-        (error-if-not ((some-fn #(instance? clojure.lang.MultiFn %)) multifn)
+        (error-if-not (instance? clojure.lang.MultiFn multifn)
           "First argument to clojure.core/prefer-method must be a multimethod: "
           (short-ds multifn))
         (original multifn dispatch-val-x dispatch-val-y)))
@@ -717,7 +717,7 @@
     (args-1-wrapper clojure.core_SLASH_methods
       [original this-var]
        ([multifn]
-        (error-if-not ((some-fn #(instance? clojure.lang.MultiFn %)) multifn)
+        (error-if-not (instance? clojure.lang.MultiFn multifn)
           "First argument to clojure.core/methods must be a multimethod: "
           (short-ds multifn))
         (original multifn)))
@@ -725,7 +725,7 @@
     (args-2-wrapper clojure.core_SLASH_get-method
       [original this-var]
        ([multifn dispatch-val]
-        (error-if-not ((some-fn #(instance? clojure.lang.MultiFn %)) multifn)
+        (error-if-not (instance? clojure.lang.MultiFn multifn)
           "First argument to clojure.core/get-method must be a multimethod: "
           (short-ds multifn))
         (original multifn dispatch-val)))
@@ -733,7 +733,7 @@
     (args-1-wrapper clojure.core_SLASH_prefers
       [original this-var]
        ([multifn]
-        (error-if-not ((some-fn #(instance? clojure.lang.MultiFn %)) multifn)
+        (error-if-not (instance? clojure.lang.MultiFn multifn)
           "First argument to clojure.core/prefers must be a multimethod: "
           (short-ds multifn))
         (original multifn)))

--- a/src/dynalint/lint.clj
+++ b/src/dynalint/lint.clj
@@ -864,7 +864,7 @@
         ; give a better error for more than 1 argument, this will always
         ; fail if given anything other than a map or nil
         (error-if (and (seq ks) (not ((some-fn map? nil?) m)))
-          "clojure.core/dissoc first argument must be a map: "
+          "clojure.core/dissoc first argument must be a map or nil: "
           (short-ds m))
         (apply original m ks))))
    #'clojure.core/update-in

--- a/test/dynalint/core_test.clj
+++ b/test/dynalint/core_test.clj
@@ -121,6 +121,52 @@
 (defmacro issues-dynalint-warning? [& body]
   true)
 
+(deftest namespace-test
+  (is (= nil (namespace 'foo)))
+  (is (= "foo" (namespace :foo/bar)))
+  (is (throws-dynalint-error?
+        (namespace "foo"))))
+
+(defmulti multimeth1 :foo)
+
+(defmethod multimeth1 "x" [_]
+  "multimeth1 for x")
+
+(deftest multimethods-test
+  ;; Do all of these in a single deftest, because some of the method
+  ;; calls have side effects, making the order important.
+
+  ;; methods
+  (is (== 1 (count (methods multimeth1))))
+  (is (throws-dynalint-error?
+       (methods 'multimeth1)))
+
+  ;; get-method
+  (is (= nil (get-method multimeth1 {:foo "x"})))
+  (is (throws-dynalint-error?
+       (get-method 'multimeth1 {:foo "x"})))
+
+  ;; prefer-method
+  (is (= multimeth1 (prefer-method multimeth1 "x" "y")))
+  (is (throws-dynalint-error?
+       (prefer-method "x" "y" multimeth1)))
+
+  ;; prefers
+  (is (= {"x" #{"y"}} (prefers multimeth1)))
+  (is (throws-dynalint-error?
+       (prefers "x")))
+
+  ;; remove-method
+  (is (= multimeth1 (remove-method multimeth1 "x")))
+  (is (throws-dynalint-error?
+       (remove-method "x")))
+
+  ;; remove-all-methods
+  (is (= multimeth1 (remove-all-methods multimeth1)))
+  (is (throws-dynalint-error?
+       (remove-all-methods "x")))
+  )
+
 (deftest meta-test
   (is (= nil (meta [])))
   (is (throws-dynalint-error?


### PR DESCRIPTION
My previous change to conj that you merged made correct checks on all args, but would print the value of the 2nd arg if it found a problem with any of them, rather than printing the problem arg value.  These changes correct that, make dissoc's message a little more precise, and remove some unnecessary some-fn calls from some of the checkers.